### PR TITLE
chore: remove useless comments and docblocks from stubs

### DIFF
--- a/stubs/cast.inbound.stub
+++ b/stubs/cast.inbound.stub
@@ -9,11 +9,6 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 
 class {{ class }} implements CastsInboundAttributes
 {
-    /**
-     * Prepare the given value for storage.
-     *
-     * @param  array<string, mixed>  $attributes
-     */
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {
         return $value;

--- a/stubs/cast.stub
+++ b/stubs/cast.stub
@@ -9,21 +9,11 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 
 class {{ class }} implements CastsAttributes
 {
-    /**
-     * Cast the given value.
-     *
-     * @param  array<string, mixed>  $attributes
-     */
     public function get(Model $model, string $key, mixed $value, array $attributes): mixed
     {
         return $value;
     }
 
-    /**
-     * Prepare the given value for storage.
-     *
-     * @param  array<string, mixed>  $attributes
-     */
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {
         return $value;

--- a/stubs/console.stub
+++ b/stubs/console.stub
@@ -9,22 +9,15 @@ use Illuminate\Console\Command;
 class {{ class }} extends Command
 {
     /**
-     * The name and signature of the console command.
-     *
      * @var string
      */
     protected $signature = '{{ command }}';
 
     /**
-     * The console command description.
-     *
      * @var string
      */
     protected $description = 'Command description';
 
-    /**
-     * Execute the console command.
-     */
     public function handle()
     {
         //

--- a/stubs/controller.api.stub
+++ b/stubs/controller.api.stub
@@ -8,41 +8,26 @@ use Illuminate\Http\Request;
 
 class {{ class }}
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
         //
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
         //
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show(string $id)
     {
         //
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, string $id)
     {
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(string $id)
     {
         //

--- a/stubs/controller.invokable.stub
+++ b/stubs/controller.invokable.stub
@@ -8,9 +8,6 @@ use Illuminate\Http\Request;
 
 class {{ class }}
 {
-    /**
-     * Handle the incoming request.
-     */
     public function __invoke(Request $request)
     {
         //

--- a/stubs/controller.model.api.stub
+++ b/stubs/controller.model.api.stub
@@ -9,41 +9,26 @@ use {{ namespacedRequests }}
 
 class {{ class }}
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
         //
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store({{ storeRequest }} $request)
     {
         //
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show({{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy({{ model }} ${{ modelVariable }})
     {
         //

--- a/stubs/controller.model.stub
+++ b/stubs/controller.model.stub
@@ -9,57 +9,36 @@ use {{ namespacedRequests }}
 
 class {{ class }}
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
         //
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create()
     {
         //
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store({{ storeRequest }} $request)
     {
         //
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show({{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit({{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update({{ updateRequest }} $request, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy({{ model }} ${{ modelVariable }})
     {
         //

--- a/stubs/controller.nested.api.stub
+++ b/stubs/controller.nested.api.stub
@@ -10,41 +10,26 @@ use Illuminate\Http\Request;
 
 class {{ class }}
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //

--- a/stubs/controller.nested.singleton.api.stub
+++ b/stubs/controller.nested.singleton.api.stub
@@ -10,33 +10,21 @@ use {{ namespacedParentModel }};
 
 class {{ class }}
 {
-    /**
-     * Store the newly created resource in storage.
-     */
     public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): never
     {
         abort(404);
     }
 
-    /**
-     * Display the resource.
-     */
     public function show({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Update the resource in storage.
-     */
     public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Remove the resource from storage.
-     */
     public function destroy({{ parentModel }} ${{ parentModelVariable }}): never
     {
         abort(404);

--- a/stubs/controller.nested.singleton.stub
+++ b/stubs/controller.nested.singleton.stub
@@ -10,49 +10,31 @@ use {{ namespacedParentModel }};
 
 class {{ class }}
 {
-    /**
-     * Show the form for creating the new resource.
-     */
     public function create({{ parentModel }} ${{ parentModelVariable }}): never
     {
         abort(404);
     }
 
-    /**
-     * Store the newly created resource in storage.
-     */
     public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): never
     {
         abort(404);
     }
 
-    /**
-     * Display the resource.
-     */
     public function show({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Show the form for editing the resource.
-     */
     public function edit({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Update the resource in storage.
-     */
     public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Remove the resource from storage.
-     */
     public function destroy({{ parentModel }} ${{ parentModelVariable }}): never
     {
         abort(404);

--- a/stubs/controller.nested.stub
+++ b/stubs/controller.nested.stub
@@ -10,57 +10,36 @@ use Illuminate\Http\Request;
 
 class {{ class }}
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create({{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
     {
         //
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
     {
         //

--- a/stubs/controller.singleton.api.stub
+++ b/stubs/controller.singleton.api.stub
@@ -8,33 +8,21 @@ use Illuminate\Http\Request;
 
 class {{ class }}
 {
-    /**
-     * Store the newly created resource in storage.
-     */
     public function store(Request $request): never
     {
         abort(404);
     }
 
-    /**
-     * Display the resource.
-     */
     public function show()
     {
         //
     }
 
-    /**
-     * Update the resource in storage.
-     */
     public function update(Request $request)
     {
         //
     }
 
-    /**
-     * Remove the resource from storage.
-     */
     public function destroy(): never
     {
         abort(404);

--- a/stubs/controller.singleton.stub
+++ b/stubs/controller.singleton.stub
@@ -8,49 +8,31 @@ use Illuminate\Http\Request;
 
 class {{ class }} 
 {
-    /**
-     * Show the form for creating the resource.
-     */
     public function create(): never
     {
         abort(404);
     }
 
-    /**
-     * Store the newly created resource in storage.
-     */
     public function store(Request $request): never
     {
         abort(404);
     }
 
-    /**
-     * Display the resource.
-     */
     public function show()
     {
         //
     }
 
-    /**
-     * Show the form for editing the resource.
-     */
     public function edit()
     {
         //
     }
 
-    /**
-     * Update the resource in storage.
-     */
     public function update(Request $request)
     {
         //
     }
 
-    /**
-     * Remove the resource from storage.
-     */
     public function destroy(): never
     {
         abort(404);

--- a/stubs/controller.stub
+++ b/stubs/controller.stub
@@ -8,57 +8,36 @@ use Illuminate\Http\Request;
 
 class {{ class }}
 {
-    /**
-     * Display a listing of the resource.
-     */
     public function index()
     {
         //
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
     public function create()
     {
         //
     }
 
-    /**
-     * Store a newly created resource in storage.
-     */
     public function store(Request $request)
     {
         //
     }
 
-    /**
-     * Display the specified resource.
-     */
     public function show(string $id)
     {
         //
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
     public function edit(string $id)
     {
         //
     }
 
-    /**
-     * Update the specified resource in storage.
-     */
     public function update(Request $request, string $id)
     {
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
     public function destroy(string $id)
     {
         //

--- a/stubs/event.stub
+++ b/stubs/event.stub
@@ -16,18 +16,13 @@ class {{ class }}
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    /**
-     * Create a new event instance.
-     */
     public function __construct()
     {
         //
     }
 
     /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return array<int, \Illuminate\Broadcasting\Channel>
+     * @return array<int, Channel>
      */
     public function broadcastOn(): array
     {

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -7,15 +7,10 @@ namespace {{ factoryNamespace }};
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\{{ namespacedModel }}>
+ * @extends Factory<\{{ namespacedModel }}>
  */
 class {{ factory }}Factory extends Factory
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [

--- a/stubs/job.queued.stub
+++ b/stubs/job.queued.stub
@@ -15,17 +15,11 @@ class {{ class }} implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    /**
-     * Create a new job instance.
-     */
     public function __construct()
     {
         //
     }
 
-    /**
-     * Execute the job.
-     */
     public function handle(): void
     {
         //

--- a/stubs/job.stub
+++ b/stubs/job.stub
@@ -10,17 +10,11 @@ class {{ class }}
 {
     use Dispatchable;
 
-    /**
-     * Create a new job instance.
-     */
     public function __construct()
     {
         //
     }
 
-    /**
-     * Execute the job.
-     */
     public function handle(): void
     {
         //

--- a/stubs/mail.stub
+++ b/stubs/mail.stub
@@ -7,6 +7,7 @@ namespace {{ namespace }};
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -15,17 +16,11 @@ class {{ class }} extends Mailable
 {
     use Queueable, SerializesModels;
 
-    /**
-     * Create a new message instance.
-     */
     public function __construct()
     {
         //
     }
 
-    /**
-     * Get the message envelope.
-     */
     public function envelope(): Envelope
     {
         return new Envelope(
@@ -33,9 +28,6 @@ class {{ class }} extends Mailable
         );
     }
 
-    /**
-     * Get the message content definition.
-     */
     public function content(): Content
     {
         return new Content(
@@ -44,9 +36,7 @@ class {{ class }} extends Mailable
     }
 
     /**
-     * Get the attachments for the message.
-     *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     * @return array<int, Attachment>
      */
     public function attachments(): array
     {

--- a/stubs/markdown-mail.stub
+++ b/stubs/markdown-mail.stub
@@ -7,6 +7,7 @@ namespace {{ namespace }};
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -15,17 +16,11 @@ class {{ class }} extends Mailable
 {
     use Queueable, SerializesModels;
 
-    /**
-     * Create a new message instance.
-     */
     public function __construct()
     {
         //
     }
 
-    /**
-     * Get the message envelope.
-     */
     public function envelope(): Envelope
     {
         return new Envelope(
@@ -33,9 +28,6 @@ class {{ class }} extends Mailable
         );
     }
 
-    /**
-     * Get the message content definition.
-     */
     public function content(): Content
     {
         return new Content(
@@ -44,9 +36,7 @@ class {{ class }} extends Mailable
     }
 
     /**
-     * Get the attachments for the message.
-     *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     * @return array<int, Attachment>
      */
     public function attachments(): array
     {

--- a/stubs/markdown-notification.stub
+++ b/stubs/markdown-notification.stub
@@ -13,17 +13,12 @@ class {{ class }} extends Notification
 {
     use Queueable;
 
-    /**
-     * Create a new notification instance.
-     */
     public function __construct()
     {
         //
     }
 
     /**
-     * Get the notification's delivery channels.
-     *
      * @return array<int, string>
      */
     public function via(object $notifiable): array
@@ -31,17 +26,12 @@ class {{ class }} extends Notification
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)->markdown('{{ view }}');
     }
 
     /**
-     * Get the array representation of the notification.
-     *
      * @return array<string, mixed>
      */
     public function toArray(object $notifiable): array

--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -11,9 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 class {{ class }}
 {
     /**
-     * Handle an incoming request.
-     *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/stubs/middleware.stub
+++ b/stubs/middleware.stub
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 class {{ class }}
 {
     /**
-     * @param  Closure(Request): (Response)  $next
+     * @param  Closure(Request): Response  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
@@ -19,9 +16,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('{{ table }}');

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -8,17 +8,11 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         //
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         //

--- a/stubs/migration.update.stub
+++ b/stubs/migration.update.stub
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
@@ -18,9 +15,6 @@ return new class extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {

--- a/stubs/notification.stub
+++ b/stubs/notification.stub
@@ -13,17 +13,12 @@ class {{ class }} extends Notification
 {
     use Queueable;
 
-    /**
-     * Create a new notification instance.
-     */
     public function __construct()
     {
         //
     }
 
     /**
-     * Get the notification's delivery channels.
-     *
      * @return array<int, string>
      */
     public function via(object $notifiable): array
@@ -31,9 +26,6 @@ class {{ class }} extends Notification
         return ['mail'];
     }
 
-    /**
-     * Get the mail representation of the notification.
-     */
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
@@ -43,8 +35,6 @@ class {{ class }} extends Notification
     }
 
     /**
-     * Get the array representation of the notification.
-     *
      * @return array<string, mixed>
      */
     public function toArray(object $notifiable): array

--- a/stubs/observer.stub
+++ b/stubs/observer.stub
@@ -8,41 +8,26 @@ use {{ namespacedModel }};
 
 class {{ class }}
 {
-    /**
-     * Handle the {{ model }} "created" event.
-     */
     public function created({{ model }} ${{ modelVariable }}): void
     {
         //
     }
 
-    /**
-     * Handle the {{ model }} "updated" event.
-     */
     public function updated({{ model }} ${{ modelVariable }}): void
     {
         //
     }
 
-    /**
-     * Handle the {{ model }} "deleted" event.
-     */
     public function deleted({{ model }} ${{ modelVariable }}): void
     {
         //
     }
 
-    /**
-     * Handle the {{ model }} "restored" event.
-     */
     public function restored({{ model }} ${{ modelVariable }}): void
     {
         //
     }
 
-    /**
-     * Handle the {{ model }} "force deleted" event.
-     */
     public function forceDeleted({{ model }} ${{ modelVariable }}): void
     {
         //

--- a/stubs/policy.plain.stub
+++ b/stubs/policy.plain.stub
@@ -8,9 +8,6 @@ use {{ namespacedUserModel }};
 
 class {{ class }}
 {
-    /**
-     * Create a new policy instance.
-     */
     public function __construct()
     {
         //

--- a/stubs/policy.stub
+++ b/stubs/policy.stub
@@ -10,57 +10,36 @@ use {{ namespacedUserModel }};
 
 class {{ class }}
 {
-    /**
-     * Determine whether the user can view any models.
-     */
     public function viewAny({{ user }} $user): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can view the model.
-     */
     public function view({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can create models.
-     */
     public function create({{ user }} $user): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can update the model.
-     */
     public function update({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can delete the model.
-     */
     public function delete({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can restore the model.
-     */
     public function restore({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
         //
     }
 
-    /**
-     * Determine whether the user can permanently delete the model.
-     */
     public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }}): bool
     {
         //

--- a/stubs/provider.stub
+++ b/stubs/provider.stub
@@ -8,17 +8,11 @@ use Illuminate\Support\ServiceProvider;
 
 class {{ class }} extends ServiceProvider
 {
-    /**
-     * Register services.
-     */
     public function register(): void
     {
         //
     }
 
-    /**
-     * Bootstrap services.
-     */
     public function boot(): void
     {
         //

--- a/stubs/request.stub
+++ b/stubs/request.stub
@@ -8,19 +8,11 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class {{ class }} extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     */
     public function authorize(): bool
     {
         return false;
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
-     */
     public function rules(): array
     {
         return [

--- a/stubs/resource-collection.stub
+++ b/stubs/resource-collection.stub
@@ -10,8 +10,6 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 class {{ class }} extends ResourceCollection
 {
     /**
-     * Transform the resource collection into an array.
-     *
      * @return array<int|string, mixed>
      */
     public function toArray(Request $request): array

--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -10,8 +10,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class {{ class }} extends JsonResource
 {
     /**
-     * Transform the resource into an array.
-     *
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array

--- a/stubs/rule.stub
+++ b/stubs/rule.stub
@@ -6,13 +6,12 @@ namespace {{ namespace }};
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 class {{ class }} implements ValidationRule
 {
     /**
-     * Run the validation rule.
-     *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/stubs/scope.stub
+++ b/stubs/scope.stub
@@ -10,9 +10,6 @@ use Illuminate\Database\Eloquent\Scope;
 
 class {{ class }} implements Scope
 {
-    /**
-     * Apply the scope to a given Eloquent query builder.
-     */
     public function apply(Builder $builder, Model $model): void
     {
         //

--- a/stubs/seeder.stub
+++ b/stubs/seeder.stub
@@ -9,9 +9,6 @@ use Illuminate\Database\Seeder;
 
 class {{ class }} extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
         //

--- a/stubs/test.stub
+++ b/stubs/test.stub
@@ -10,9 +10,6 @@ use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {
-    /**
-     * A basic feature test example.
-     */
     public function test_example(): void
     {
         $response = $this->get('/');

--- a/stubs/test.unit.stub
+++ b/stubs/test.unit.stub
@@ -8,9 +8,6 @@ use PHPUnit\Framework\TestCase;
 
 class {{ class }} extends TestCase
 {
-    /**
-     * A basic unit test example.
-     */
     public function test_example(): void
     {
         $this->assertTrue(true);

--- a/stubs/view-component.stub
+++ b/stubs/view-component.stub
@@ -10,17 +10,11 @@ use Illuminate\Contracts\View\View;
 
 class {{ class }} extends Component
 {
-    /**
-     * Create a new component instance.
-     */
     public function __construct()
     {
         //
     }
 
-    /**
-     * Get the view / contents that represent the component.
-     */
     public function render(): View|Closure|string
     {
         return {{ view }};


### PR DESCRIPTION
# ⚡ Remove pointless comments/docblocks from Laravel boilerplate stubs - [86dr2vfcq](https://app.clickup.com/t/86dr2vfcq) ⚡

## 💻 What type of change is this?

- [ ] 💎 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Styling
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI

## ⭐ Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
Example:
-->

I've removed unnecessary comment and docblocks from stubs 


## 📷 Screenshots

<!--
Please include before AND after screenshots of the change.
-->

### Before
<img width="736" alt="image" src="https://github.com/Light-it-labs/laravel/assets/68563891/2f9f011b-34ad-443c-bc03-748ba6878b55">

### After
<img width="677" alt="image" src="https://github.com/Light-it-labs/laravel/assets/68563891/9967845e-43d7-4af9-ba0b-d782c0dd1d37">



## ✅ Checklist

- [x] This PR can be merged (it is not a draft, work in progress, or blocked on another PR)
- [ ] I have tested this change locally in multiple screen sizes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
